### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,7 +75,8 @@
     "tesseract.js": "^6.0.1",
     "vaul": "^0.9.3",
     "xlsx": "^0.18.5",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/frontend/src/api/fileProcessing.ts
+++ b/frontend/src/api/fileProcessing.ts
@@ -2,6 +2,7 @@ import { createWorker } from 'tesseract.js';
 import * as XLSX from 'xlsx';
 import mammoth from 'mammoth';
 import JSZip from 'jszip';
+import sanitizeHtml from 'sanitize-html';
 
 export interface ProcessedFile {
   filename: string;
@@ -244,10 +245,12 @@ export class FileProcessor {
   private static async processHTML(file: File): Promise<{ content: string; metadata: any }> {
     const htmlContent = await file.text();
     
-    const textContent = htmlContent
-      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-      .replace(/<[^>]*>/g, ' ')
+    const sanitizedContent = sanitizeHtml(htmlContent, {
+      allowedTags: [],
+      allowedAttributes: {}
+    });
+
+    const textContent = sanitizedContent
       .replace(/\s+/g, ' ')
       .trim();
 


### PR DESCRIPTION
Potential fix for [https://github.com/HyperKuvid-Labs/t3/security/code-scanning/1](https://github.com/HyperKuvid-Labs/t3/security/code-scanning/1)

To address the issue, the best approach is to replace the custom regular expression with a well-tested HTML sanitization library, such as `sanitize-html`. This library is designed to handle edge cases and ensure safe removal of unwanted tags, including `<script>` and `<style>`. It will also simplify the code and reduce the risk of introducing security vulnerabilities.

**Steps to fix:**
1. Install the `sanitize-html` library.
2. Replace the regex-based filtering logic in the `processHTML` method with `sanitize-html` to remove `<script>` and `<style>` tags and extract text content safely.
3. Update the metadata calculations to reflect the sanitized content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
